### PR TITLE
New navigation and copy|paste shortcuts, and visual feedback

### DIFF
--- a/brain-mode.el
+++ b/brain-mode.el
@@ -96,9 +96,9 @@
     ("n" . brain-navigate-to-target-atom-and-kill-buffer)
     ("p" . brain-push-view)
     ("t" . brain-navigate-to-target-atom)
+    ("v" . yank)
     ("w" . kill-buffer)
     ("x" . kill-region)
-    ("y" . yank)
 )))
 
 

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -80,6 +80,7 @@
 (if (boundp 'brain-move-submode-map) ()
   (defconst brain-move-submode-map '(
     ("b" . brain-update-to-backward-view)
+    ("c" . kill-ring-save)
     ("f" . brain-update-to-forward-view)
     ("g" . brain-update-view)
     ("h" . brain-set-view-height-prompt)
@@ -91,9 +92,13 @@
     ("K" . scroll-up-command)
     ("l" . forward-char)  ;; right
     ("L" . move-end-of-line)
+    ("m" . set-mark-command)
+    ("n" . brain-navigate-to-target-atom-and-kill-buffer)
     ("p" . brain-push-view)
     ("t" . brain-navigate-to-target-atom)
     ("w" . kill-buffer)
+    ("x" . kill-region)
+    ("y" . yank)
 )))
 
 
@@ -1424,6 +1429,13 @@ a type has been assigned to it by the inference engine."
   (dolist (m brain-move-submode-map)
     (let ((key (car m)) (symbol (cdr m)))
      (define-key brain-mode-map (kbd key) 'nil))))
+
+(defun brain-navigate-to-target-atom-and-kill-buffer ()
+  (interactive)
+  (let ((bname (buffer-name)))
+    (progn (brain-navigate-to-target-atom)
+	   (kill-buffer bname)
+	   )))
 
 (defvar brain-move-submode nil)
 (defun brain-toggle-move-or-edit-submode ()

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -29,6 +29,7 @@
 ;;     (defvar brain-default-edges-file "/tmp/joshkb-edges.tsv")
 ;;     (defvar brain-default-pagerank-file "/tmp/joshkb-pagerank.tsv")
 
+(defvar brain-default-freeplane-file "/home/jeff/work/mm/tf.mm")
 
 ;; DEPENDENCIES ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1433,10 +1434,12 @@ a type has been assigned to it by the inference engine."
     (progn (setq brain-move-submode 'nil)
            (brain-use-edit-submode)
 	   (message "submode: edit")
+	   (set-cursor-color "#000000")
 	   )
     (progn (setq brain-move-submode t)
            (brain-use-move-submode)
 	   (message "submode: move")
+	   (set-cursor-color "#00ff00")
 	   )
     )
   )

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -79,17 +79,22 @@
 
 (if (boundp 'brain-move-submode-map) ()
   (defconst brain-move-submode-map '(
-    ("k" . next-line)  ;; up
-    ("i" . previous-line)  ;; down
-    ("l" . forward-char)  ;; right
-    ("j" . backward-char)  ;; left
-    ("w" . kill-buffer)
-    ("t" . brain-navigate-to-target-atom)
-    ("f" . brain-update-to-forward-view)
     ("b" . brain-update-to-backward-view)
-    ("h" . brain-set-view-height-prompt)
+    ("f" . brain-update-to-forward-view)
     ("g" . brain-update-view)
-    ("p" . brain-push-view))))
+    ("h" . brain-set-view-height-prompt)
+    ("i" . previous-line)  ;; up
+    ("I" . scroll-down-command)
+    ("j" . backward-char)  ;; left
+    ("J" . move-beginning-of-line)
+    ("k" . next-line)  ;; down
+    ("K" . scroll-up-command)
+    ("l" . forward-char)  ;; right
+    ("L" . move-end-of-line)
+    ("p" . brain-push-view)
+    ("t" . brain-navigate-to-target-atom)
+    ("w" . kill-buffer)
+)))
 
 
 ;; BUFFER-LOCAL CONTEXT ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -94,7 +94,7 @@
     ("L" . move-end-of-line)
     ("m" . set-mark-command)
     ("n" . brain-navigate-to-target-atom-and-kill-buffer)
-    ("p" . brain-push-view-prompt)
+    ("p" . brain-push-view-prompt) ;; shortcut is effectively "p z"
     ("t" . brain-navigate-to-target-atom)
     ("v" . yank)
     ("w" . kill-buffer)

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -370,10 +370,21 @@
           (clipboard-kill-ring-save beg end))
         (kill-buffer buffer)))))
 
-(defun kill-other-buffers ()
-  "Kill all other buffers."
+(defun brain-kill-other-buffers ()
+  "Kill all other brain-mode buffers."
   (interactive)
-  (mapc 'kill-buffer (delq (current-buffer) (buffer-list))))
+  (mapc 'kill-buffer
+	(my-filter
+	 (lambda (bname)
+	   (eq (buffer-local-value 'major-mode (get-buffer bname))
+	       'brain-mode))
+	 (delq (current-buffer) (buffer-list))
+	 )))
+
+(defun my-filter (condp lst)
+  ;; https://www.emacswiki.org/emacs/ElispCookbook
+  (delq nil
+	(mapcar (lambda (x) (and (funcall condp x) x)) lst)))
 
 
 ;; NAVIGATION ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1531,7 +1542,7 @@ a type has been assigned to it by the inference engine."
     (define-key brain-mode-map (kbd "C-c u")           'brain-update-view)
     (define-key brain-mode-map (kbd "C-c m")           'brain-toggle-move-or-edit-submode)
     ;; convenience functions
-    (define-key brain-mode-map (kbd "C-x C-k o")       'kill-other-buffers)
+    (define-key brain-mode-map (kbd "C-x C-k o")       'brain-kill-other-buffers)
 ))
 
 ;; special mappings reserved for use through emacsclient

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -94,13 +94,19 @@
     ("L" . move-end-of-line)
     ("m" . set-mark-command)
     ("n" . brain-navigate-to-target-atom-and-kill-buffer)
-    ("p q" . brain-push-view)
+    ("p" . brain-push-view-prompt)
     ("t" . brain-navigate-to-target-atom)
     ("v" . yank)
     ("w" . kill-buffer)
     ("x" . kill-region)
 )))
 
+(defun brain-push-view-prompt ()
+  (interactive)
+  (if (eq (read-char "really push view? (press 'z' to confirm)") 122)
+      (brain-push-view)
+      nil
+    ))
 
 ;; BUFFER-LOCAL CONTEXT ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/brain-mode.el
+++ b/brain-mode.el
@@ -94,7 +94,7 @@
     ("L" . move-end-of-line)
     ("m" . set-mark-command)
     ("n" . brain-navigate-to-target-atom-and-kill-buffer)
-    ("p" . brain-push-view)
+    ("p q" . brain-push-view)
     ("t" . brain-navigate-to-target-atom)
     ("v" . yank)
     ("w" . kill-buffer)


### PR DESCRIPTION
change cursor color to indicate move|edit submode
    green = move submode, black = edit submode

new shortcuts
    page up (I), down (K), left (J), right (L)
    n : navigate to target atom and kill previous buffer (is new command)
    x : kill-region ("cut")
    c : kill-ring-save ("copy")
    v : yank ("paste")
    m : toggle mark ("highlight")
